### PR TITLE
misc: adds download counter for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # React Localization Storage Manager / react-lsm
 
+![NPM Downloads](https://img.shields.io/npm/dw/react-lsm)
+
 ![react-jumbo](https://github.com/lewissmatos/react-lsm/assets/63300185/39ef7d79-44f1-46a9-b349-61ba01c96881)
 
 ## Package


### PR DESCRIPTION
This PR adds a commit that includes the download counter extracted from NPM to the repo for popularity check. ( See attached picture for reference of badge ) 

!important: no changes on functionalities.

<img width="161" alt="Badge Reference" src="https://github.com/lewissmatos/react-lsm/assets/112432349/c8603276-51d7-4dc9-8f69-0f8d2da01310">

( Number not accurate, taken from another repo )
